### PR TITLE
fix load diagrams on instant navigation

### DIFF
--- a/docs/js/extra.js
+++ b/docs/js/extra.js
@@ -1,0 +1,22 @@
+// Drawio viewer script
+window.DRAW_IO_VIEWER_SRC =
+  "https://viewer.diagrams.net/js/viewer-static.min.js";
+// Fix math import path
+window.DRAW_MATH_URL = "https://viewer.diagrams.net/math/es5";
+
+// Executes on `DOMContentLoaded` and on instant navigation
+document$.subscribe(function (evt) {
+  // load script if not in DOM
+  if (document.querySelector(`[src="${DRAW_IO_VIEWER_SRC}"]`) == null) {
+    const script = document.createElement("script");
+    script.src = DRAW_IO_VIEWER_SRC;
+    document.head.appendChild(script);
+  }
+
+  // Trigger load drawio diagrams after instant.navigation
+  if (null != window.onDrawioViewerLoad) {
+    window.onDrawioViewerLoad();
+  } else if ("GraphViewer" in window) {
+    GraphViewer.processElements();
+  }
+});

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,17 +1,16 @@
 site_name: Test Site
 
 nav:
-  - Landing Page: 
-    - index.md
+  - Landing Page:
+      - index.md
   - Page One: page_one/index.md
 
-
 plugins:
-    - search
-    - drawio_file
+  - search
+  - drawio_file
 
-#extra_javascript:
-#  - javascripts/viewer-static.min.js
+extra_javascript:
+  - js/extra.js
 
 theme:
   name: material
@@ -35,16 +34,16 @@ theme:
   features:
     - content.action.view
     - content.action.edit
-    - content.tabs.link 
+    - content.tabs.link
     - content.code.copy
     - content.code.annotate
     - content.code.select
     - navigation.footer
     - navigation.indexes
     ## Disable instant for now as it creates issues with loading
-    ## draw.io diagrams. 
-    # - navigation.instant # <------------------------------------------culprit
-    #- navigation.instant.progress
+    ## draw.io diagrams.
+    - navigation.instant # <------------------------------------------culprit
+    - navigation.instant.progress
     - navigation.path
     - navigation.tabs
     - navigation.tabs.sticky


### PR DESCRIPTION
Fixes issues with draw-io diagrams and instant navigation.

While at it, since it irritated me that there were failed requests for `math/es5`, fixed that as well.

Issue seems to be that:

1.  on pages without diagrams, the viewer script is not automatically loaded
2. instant navigation to a page with a diagram does not load script (while a full refresh does)

So to solve, I just brute force a load of the script if not available and then, after instant navigation, trigger (global) functions in the script that pick up on diagrams on the page in question.

You could ofc make it even better and only load the script when there is an actual diagram on the page.
